### PR TITLE
Change error display to warning

### DIFF
--- a/htdocs/luci-static/resources/view/settings.js
+++ b/htdocs/luci-static/resources/view/settings.js
@@ -491,10 +491,16 @@ return view.extend({
                 var displayType = type.charAt(0).toUpperCase() + type.slice(1);
                 var icon, color;
                 var statusLower = status ? status.toLowerCase() : '';
-                var isIntegrity = type && type.toLowerCase().indexOf('integr') !== -1;
-                if (isIntegrity && statusLower !== 'ok') {
-                    icon = '⚠';
-                    color = 'orange';
+                var typeLower = type ? type.trim().toLowerCase() : '';
+                var isIntegrity = (typeLower === 'integrity');
+                if (isIntegrity) {
+                    if (statusLower === 'ok') {
+                        icon = '✓';
+                        color = 'green';
+                    } else {
+                        icon = '⚠';
+                        color = 'orange';
+                    }
                 } else {
                     switch(statusLower) {
                         case 'enabled':


### PR DESCRIPTION
Display integrity status as a warning instead of an error to better reflect file modifications without implying functional failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbf2e0c4-e6e2-4d95-a1e7-42103211f280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbf2e0c4-e6e2-4d95-a1e7-42103211f280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

