### PR TITLE
Add fq-pie support to luci-app-qosmate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ wget -O /www/luci-static/resources/view/qosmate/connections.js https://raw.githu
 wget -O /www/luci-static/resources/view/qosmate/custom_rules.js https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/htdocs/luci-static/resources/view/custom_rules.js && \
 wget -O /www/luci-static/resources/view/qosmate/ipsets.js https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/htdocs/luci-static/resources/view/ipsets.js && \
 wget -O /www/luci-static/resources/view/qosmate/statistics.js https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/htdocs/luci-static/resources/view/statistics.js && \
+wget -O /www/luci-static/resources/view/qosmate/statistics.js https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/htdocs/luci-static/resources/view/htb.js && \
 wget -O /usr/share/luci/menu.d/luci-app-qosmate.json https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/root/usr/share/luci/menu.d/luci-app-qosmate.json && \
 wget -O /usr/share/rpcd/acl.d/luci-app-qosmate.json https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/root/usr/share/rpcd/acl.d/luci-app-qosmate.json && \
 wget -O /usr/libexec/rpcd/luci.qosmate https://raw.githubusercontent.com/hudra0/luci-app-qosmate/main/root/usr/libexec/rpcd/luci.qosmate && \

--- a/htdocs/luci-static/resources/view/hfsc.js
+++ b/htdocs/luci-static/resources/view/hfsc.js
@@ -56,9 +56,9 @@ function addRelevanceInfo(description, settingName, rootQdisc, gameqdisc) {
         
         // Check hybrid-specific settings
         if (rootQdisc === 'hybrid') {
-            if (settingName === 'nongameqdisc' || settingName === 'nongameqdiscoptions') {
+            if (settingName === 'nongameqdiscoptions') {
                 isRelevant = false;
-                note = ' ⚠ Hybrid mode uses CAKE for default class and fq_codel for bulk traffic';
+                note = ' ⚠ Hybrid mode uses CAKE for default class and fq_codel / fq_pie for bulk traffic';
             }
         }
         
@@ -124,7 +124,7 @@ return view.extend({
             if (rootQdisc === 'hfsc') {
                 relevanceText = _('HFSC mode active.');
             } else if (rootQdisc === 'hybrid') {
-                relevanceText = _('Hybrid mode - these settings control realtime traffic (high priority class).');
+                relevanceText = _('Hybrid mode - these settings control realtime traffic (high priority class) AND bulk traffic.');
             } else {
                 relevanceText = _('Current Root QDisc is %s - HFSC settings are not used.').format(rootQdisc.toUpperCase());
             }
@@ -158,6 +158,7 @@ return view.extend({
             addRelevanceInfo(_('Queueing method for traffic classified as realtime'), 'gameqdisc', rootQdisc, gameqdisc));
         o.value('pfifo', _('PFIFO'));
         o.value('fq_codel', _('FQ_CODEL'));
+        o.value('fq_pie', _('FQ_PIE'));
         o.value('bfifo', _('BFIFO'));
         o.value('red', _('RED'));
         o.value('netem', _('NETEM'));
@@ -166,11 +167,22 @@ return view.extend({
         createOption('GAMEUP', _('Game Upload (kbps)'), _('Bandwidth reserved for realtime upload traffic'), _('Default: 15% of UPRATE + 400'), 'uinteger');
         createOption('GAMEDOWN', _('Game Download (kbps)'), _('Bandwidth reserved for realtime download traffic'), _('Default: 15% of DOWNRATE + 400'), 'uinteger');
 
-        o = s.option(form.ListValue, 'nongameqdisc', _('Non-Game Queue Discipline'), 
-            addRelevanceInfo(_('Select the queueing discipline for non-realtime traffic'), 'nongameqdisc', rootQdisc, gameqdisc));
-        o.value('fq_codel', _('FQ_CODEL'));
-        o.value('cake', _('CAKE'));
-        o.default = 'fq_codel';
+        if (rootQdisc === 'hfsc') {
+            o = s.option(form.ListValue, 'nongameqdisc', _('Non-Game Queue Discipline'), 
+                addRelevanceInfo(_('Select the queueing discipline for non-realtime traffic'), 'nongameqdisc', rootQdisc, gameqdisc));
+            o.value('fq_codel', _('FQ_CODEL'));
+            o.value('fq_pie', _('FQ_PIE'));
+            o.value('cake', _('CAKE'));
+            o.default = 'fq_codel';
+        }
+        else { // rootQdisc is hybrid, or not relevant
+            o = s.option(form.ListValue, 'nongameqdisc', _('Non-Game Queue Discipline'), 
+                addRelevanceInfo(_('Select the queueing discipline for bulk traffic'), 'nongameqdisc', rootQdisc, gameqdisc));
+            o.value('fq_codel', _('FQ_CODEL'));
+            o.value('fq_pie', _('FQ_PIE'));
+            o.default = 'fq_codel';
+        }
+        
 
         createOption('nongameqdiscoptions', _('Non-Game QDisc Options'), _('Cake options for non-realtime queueing discipline'), _('Default: besteffort ack-filter'));
         createOption('MAXDEL', _('Max Delay (ms)'), _('Target max delay for realtime packets after burst (pfifo, bfifo, red)'), _('Default: 24'), 'uinteger');

--- a/htdocs/luci-static/resources/view/htb.js
+++ b/htdocs/luci-static/resources/view/htb.js
@@ -1,0 +1,82 @@
+'use strict';
+'require view';
+'require form';
+'require ui';
+'require uci';
+'require rpc';
+'require fs';
+
+// Helper function to add relevance info to descriptions
+function addRelevanceInfo(description, rootQdisc) {
+    var note = '';
+    
+    // Check ROOT_QDISC relevance
+    if (rootQdisc !== 'htb') {
+        note = ' ⚠ Not used with ' + rootQdisc.toUpperCase();
+    } else {
+        note = ' ✓ Active for ' + rootQdisc.toUpperCase();
+    }
+    
+    return description + note;
+}
+
+var callInitAction = rpc.declare({
+    object: 'luci',
+    method: 'setInitAction',
+    params: ['name', 'action'],
+    expect: { result: false }
+});
+
+return view.extend({
+    handleSaveApply: function(ev) {
+        return this.handleSave(ev)
+            .then(() => ui.changes.apply())
+            .then(() => uci.load('qosmate'))
+            .then(() => uci.get_first('qosmate', 'global', 'enabled'))
+            .then(enabled => {
+                if (enabled === '0') {
+                    return fs.exec_direct('/etc/init.d/qosmate', ['stop']);
+                } else {
+                    return fs.exec_direct('/etc/init.d/qosmate', ['restart']);
+                }
+            })
+            .then(() => {
+                ui.hideModal();
+                window.location.reload();
+            })
+            .catch(err => {
+                ui.hideModal();
+                ui.addNotification(null, E('p', _('Failed to save settings or update QoSmate service: ') + err.message));
+            });
+    },
+
+    render: function() {
+        return Promise.all([
+            uci.load('qosmate')
+        ]).then(() => {
+            var m, s, o;
+            var rootQdisc = uci.get('qosmate', 'settings', 'ROOT_QDISC') || 'hfsc';
+            var htbQdisc = uci.get('qosmate', 'htb', 'htbqdisc') || 'fq_codel';
+
+            var relevanceText = '';
+            if (rootQdisc === 'hfsc') {
+                relevanceText = _('HTB mode active.');
+            } else {
+                relevanceText = _('Current Root QDisc is %s - HTB settings are not used.').format(rootQdisc.toUpperCase());
+            }
+
+            m = new form.Map('qosmate', _('QoSmate HTB Settings (Experimental)'), _('Configure HTB qdisc for QoSmate.') + ' ' + relevanceText);
+
+            s = m.section(form.NamedSection, 'htb', 'htb', _('HTB Settings'));
+            s.anonymous = true;
+
+        o = s.option(form.ListValue, 'htbqdisc', _('HTB Internal Queue Discipline'), 
+            addRelevanceInfo(_('Queueing method for 3 htb traffic classes, configured with slightly different params.'), rootQdisc));
+        o.value('fq_codel', _('FQ_CODEL'));
+        o.value('fq_pie', _('FQ_PIE'));
+        o.default = 'fq_codel';
+
+        return m.render();
+        });
+    }
+});

--- a/htdocs/luci-static/resources/view/settings.js
+++ b/htdocs/luci-static/resources/view/settings.js
@@ -777,7 +777,7 @@ return view.extend({
                     return base + mqStatus;
                 }
                 case 'hybrid':
-                    return _('Hybrid - HFSC as shaper, Game Qdisc for realtime traffic, CAKE for default traffic and fq_codel for bulk traffic. Configure realtime class settings in HFSC tab and default class settings in CAKE tab.');
+                    return _('Hybrid - HFSC as shaper, Game Qdisc for realtime traffic, CAKE for default traffic and fq_codel / fq_pie for bulk traffic. Configure realtime, bulk class settings in HFSC tab and default class settings in CAKE tab.');
                 case 'htb':
                     return _('HTB - Hierarchical Token Bucket. Simple 3-tier priority system with pre-configured settings - no additional qdisc configuration required.');
                 default:

--- a/root/usr/share/luci/menu.d/luci-app-qosmate.json
+++ b/root/usr/share/luci/menu.d/luci-app-qosmate.json
@@ -89,5 +89,13 @@
             "type": "view",
             "path": "qosmate/statistics"
         }
+    },
+    "admin/network/qosmate/htb": {
+        "title": "HTB",
+        "order": 90,
+        "action": {
+            "type": "view",
+            "path": "qosmate/htb"
+        }
     }
 }


### PR DESCRIPTION
This PR adds fq-pie qdisc to luci-app-qosmate, as an option for gameqdisc & nongameqdisc in the hfsc.js view, as well as adding a new view htb.js  to choose between fq_codel and fq_pie for htb.

Refer the corresponding PR necessary for qosmate here: [https://github.com/hudra0/qosmate/pull/114](https://github.com/hudra0/qosmate/pull/114)